### PR TITLE
Allow specify other options from type-coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Under the hood it uses [type-coverage](https://github.com/plantain-00/type-cover
 interface Options {
   tsconfigPath?: string; //defaults to tsconfig.json
   name?: string; // defaults to Type Coverage
+  ignoreFiles?: string[];
+  ignoreCatch?: boolean;
+  atLeast?: number;
+  strict?: boolean;
 }
 ```
 
@@ -54,6 +58,30 @@ Path to typescript project configuration
 optional `string`<br>\
 Defaults: `Type Coverage`<br>\
 Specify the name for check. Might be useful in monorepos.
+
+##### ignoreFiles
+
+optional `string[]`<br>\
+Defaults: `undefined`<br>\
+Specify the ignored for checks files.
+
+##### ignoreCatch
+
+optional `string`<br>\
+Defaults: `undefined`<br>\
+See [type-coverage's description](https://github.com/plantain-00/type-coverage#ignore-catch) for the reference.
+
+##### atLeast
+
+optional `string`<br>\
+Defaults: `undefined`<br>\
+Fail if coverage rate < this value.
+
+##### strict
+
+optional `string`<br>\
+Defaults: `undefined`<br>\
+See [type-coverage's description](https://github.com/plantain-00/type-coverage#strict-mode) for the reference.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.11",
-    "type-coverage": "^1.10.0"
+    "type-coverage-core": "^2.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/src/__mocks__/type-coverage-core.ts
+++ b/src/__mocks__/type-coverage-core.ts
@@ -1,3 +1,3 @@
-import * as TypeCoverage from "type-coverage";
+import * as TypeCoverage from "type-coverage-core";
 
 export const lint: typeof TypeCoverage.lint = jest.fn();

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 import { typeCoverageWatcher } from "../index";
-import { lint } from "type-coverage";
+import { lint } from "type-coverage-core";
 import { codechecks } from "@codechecks/client";
 import { TypeCoverageArtifact, RawTypeCoverageReport } from "../types";
 
@@ -7,7 +7,7 @@ type Mocked<T> = { [k in keyof T]: jest.Mock<T[k]> };
 
 describe("type-coverage", () => {
   const codechecksMock = require("../__mocks__/@codechecks/client").codechecks as Mocked<typeof codechecks>;
-  const typeCoverageMock = require("../__mocks__/type-coverage").lint as jest.Mock<typeof lint>;
+  const typeCoverageMock = require("../__mocks__/type-coverage-core").lint as jest.Mock<typeof lint>;
   beforeEach(() => jest.resetAllMocks());
 
   it("should work not in PR context", async () => {
@@ -148,6 +148,38 @@ describe("type-coverage", () => {
         "name": "Type Coverage",
         "shortDescription": "Change: +100.00% Total: 100.00% New typed symbols: 2",
         "status": "success",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": undefined,
+    },
+  ],
+}
+`);
+  });
+
+  it("should handle atLeast option", async () => {
+    codechecksMock.isPr.mockReturnValue(true);
+    typeCoverageMock.mockReturnValue({
+      correctCount: 4,
+      totalCount: 10,
+      anys: [],
+      program: undefined as any,
+    });
+
+    await typeCoverageWatcher({ tsconfigPath: "./tsconfig.json", atLeast: 50 });
+    expect(codechecks.report).toMatchInlineSnapshot(`
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Object {
+        "longDescription": "New untyped symbols: 0",
+        "name": "Type Coverage",
+        "shortDescription": "Change: +40.00% (limit 50.00%) Total: 40.00% New typed symbols: 4",
+        "status": "failure",
       },
     ],
   ],

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,14 +1,19 @@
-import { AnyInfo } from "type-coverage/dist/interfaces";
+import { AnyInfo } from "type-coverage-core";
 
 export interface Options {
   tsconfigPath?: string;
   name?: string;
+  ignoreFiles?: string[];
+  ignoreCatch?: boolean;
+  atLeast?: number;
+  strict?: boolean;
 }
 
 export interface NormalizedOptions {
   tsconfigPath: string;
   name: string;
   artifactName: string;
+  atLeast?: number;
 }
 
 export interface TypeCoverageArtifact {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1284,7 +1284,19 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@7.1.3, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
+glob@7:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
+  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
@@ -2446,7 +2458,7 @@ mimic-fn@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
-minimatch@^3.0.3, minimatch@^3.0.4:
+minimatch@3, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -2458,7 +2470,7 @@ minimist@0.0.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
-minimist@1.2.0, minimist@^1.1.1, minimist@^1.2.0:
+minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
@@ -3657,6 +3669,14 @@ ts-jest@^23.10.5:
     semver "^5.5"
     yargs-parser "10.x"
 
+ts-lib-utils@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ts-lib-utils/-/ts-lib-utils-2.2.0.tgz#dbf198ba67e2fee027f36bd2f9c0cbd638ed1731"
+  integrity sha512-yfZWuQs5bfQA2RLJdHUOSL2+Iw4NcZ8eKglVVW25aXi3sdLEoJxHB3tC2CN+x4MY4X39tcFCGlE5V7IF8O3m8w==
+  dependencies:
+    glob "7"
+    tslib "1"
+
 ts-node@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.1.tgz#9562dc2d1e6d248d24bc55f773e3f614337d9baf"
@@ -3682,7 +3702,12 @@ ts-node@^8.0.2:
     source-map-support "^0.5.6"
     yn "^3.0.0"
 
-tslib@1, tslib@^1.8.0, tslib@^1.8.1:
+tslib@1:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
+  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tslib@^1.8.0, tslib@^1.8.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
@@ -3728,9 +3753,9 @@ tslint@^5.12.1:
     tsutils "^2.29.0"
 
 tsutils@3:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.9.1.tgz#2a40dc742943c71eca6d5c1994fcf999956be387"
-  integrity sha512-hrxVtLtPqQr//p8/msPT1X1UYXUjizqSit5d9AQ5k38TcV38NyecL5xODNxa73cLe/5sdiJ+w1FqzDhRBA/anA==
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.14.1.tgz#f1d2b93d2a0876481f2f1f98c25ba42bbd7ee860"
+  integrity sha512-kiuZzD1uUA5DxGj/uxbde+ymp6VVdAxdzOIlAFbYKrPyla8/uiJ9JLBm1QsPhOm4Muj0/+cWEDP99yoCUcSl6Q==
   dependencies:
     tslib "^1.8.1"
 
@@ -3767,18 +3792,17 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-coverage@^1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/type-coverage/-/type-coverage-1.10.0.tgz#da9d664389126b54a8bd38beb6defd5fb9d2fc14"
-  integrity sha512-+mL02T3iM1gJ/ZK4txyQqj6Sq58jbgD4UeMhG8KBdFcIY/vwOVTeds7R7O8dAnzbiE24pgK5fPlciRWlBdt15w==
+type-coverage-core@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/type-coverage-core/-/type-coverage-core-2.2.0.tgz#436ebe4f1b7bfd36ab019c840147fbcbb4bd4f1f"
+  integrity sha512-b7NTFy8HSo57C0zvJK5Vy8K+KWmQEyCFvXE7E8I6VXtt6clHuDg8z4L+CfnSGtt1ZovDu2C6+qjmBgdTZHeJyw==
   dependencies:
-    glob "7.1.3"
-    minimist "1.2.0"
+    minimatch "3"
+    ts-lib-utils "^2.2.0"
     tslib "1"
     tsutils "3"
-    typescript "2 || 3"
 
-"typescript@2 || 3", typescript@^3.2.2:
+typescript@^3.2.2:
   version "3.3.3333"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3333.tgz#171b2c5af66c59e9431199117a3bcadc66fdcfd6"
   integrity sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==


### PR DESCRIPTION
Fixes #4

I believe it's breaking change since it updates type-coverage to the next major version (and even uses different package).